### PR TITLE
Sort packages lists to remove false positives

### DIFF
--- a/nix-script-diff-generations.sh
+++ b/nix-script-diff-generations.sh
@@ -114,9 +114,15 @@ stdout "Generation packages written for $GEN_B"
 
 stdout "Diffing now..."
 
-diff -u $versA $versB | grep "nix/store" | sed 's:/nix/store/: :' | \
-    grep -E "^(\+|\-).*" | sed -r 's:(.) ([a-z0-9]*)-(.*):\1 \3:' | \
-        sort -k 2 -k 1,1r
+diff -u $versA $versB | \
+    # Select only lines that differ.
+    # (no context, no file name, no line number, etc.)
+    grep '^[+-]/nix/store' | \
+    # Remove the "/nix/store/<hash>" garbage.
+    # Add a space instead, to separate the [+-] from the name.
+    sed 's:/nix/store/[^-]*-: :' | \
+    # sort by name, then prefer '+' over '-'.
+    sort -k 2 -k 1,1r
 
 stdout "Removing tmp directories"
 

--- a/nix-script-diff-generations.sh
+++ b/nix-script-diff-generations.sh
@@ -116,7 +116,7 @@ stdout "Diffing now..."
 
 diff -u $versA $versB | grep "nix/store" | sed 's:/nix/store/: :' | \
     grep -E "^(\+|\-).*" | sed -r 's:(.) ([a-z0-9]*)-(.*):\1 \3:' | \
-        sort -k 1.44
+        sort -k 2 -k 1,1r
 
 stdout "Removing tmp directories"
 

--- a/nix-script-diff-generations.sh
+++ b/nix-script-diff-generations.sh
@@ -103,13 +103,13 @@ fi
 
 versA=$(mktemp)
 stdout "TMP file '$versA' created"
-nix-store -qR $DIR_A > $versA
+nix-store -qR $DIR_A | sort -t'-' -k 2 > $versA
 stdout "Generation packages written for $GEN_A"
 
 
 versB=$(mktemp)
 stdout "TMP file '$versB' created"
-nix-store -qR $DIR_B > $versB
+nix-store -qR $DIR_B | sort -t'-' -k 2 > $versB
 stdout "Generation packages written for $GEN_B"
 
 stdout "Diffing now..."


### PR DESCRIPTION
The order of pacakges listed by `nix-env -q` is determined by the hash of the packages.
When comparing theses lists, diff has trouble telling reordered lines from modified/changed ones.

By sorting the list according to the package name, diff esily finds modified packages.