### PR TITLE
Fix: move path removing to helper

### DIFF
--- a/nix-script
+++ b/nix-script
@@ -92,8 +92,7 @@ then
     stdout "Listing commands"
     for cmd in $(all_commands)
     do
-        echo $(scriptname_to_command $cmd | \
-            sed -r "s,$(dirname ${BASH_SOURCE[0]})/nix-script-,,")
+        echo $(scriptname_to_command $cmd)
     done
     exit 0
 fi

--- a/nix-utils.sh
+++ b/nix-utils.sh
@@ -13,7 +13,8 @@ stdout() {
 }
 
 scriptname_to_command() {
-        echo "$1" | sed 's,^\.\/nix-script-,,' | sed 's,\.sh$,,'
+        echo "$1" | sed 's,^\.\/nix-script-,,' | sed 's,\.sh$,,' | \
+            sed -r "s,$(dirname ${BASH_SOURCE[0]})/nix-script-,,"
 }
 
 help_synopsis() {


### PR DESCRIPTION
With the path-removing code in the helper function
"scriptname_to_command" we have also closed the issue that the help text
includes the full path of the command.

Close #22