### PR TITLE
Update package def parallel

### DIFF
--- a/example.rc
+++ b/example.rc
@@ -42,3 +42,15 @@ RC_SWITCH_DEFAULT_TAG_FLAGS_NIXPKGS=""
 #
 RC_CONTAINER_CONF_TEMPLATE_DIR=~/.nixos-scripts-container-conf-templates/
 
+
+#
+#
+# Command: update-package-def
+#
+#
+
+#
+# default number to pass to "nix-build -j"
+#
+RC_UPD_NIX_BUILD_J=2
+

--- a/example.rc
+++ b/example.rc
@@ -54,3 +54,8 @@ RC_CONTAINER_CONF_TEMPLATE_DIR=~/.nixos-scripts-container-conf-templates/
 #
 RC_UPD_NIX_BUILD_J=2
 
+#
+# default number to pass to "nix-build --cores"
+#
+RC_UPD_NIX_BUILD_CORES=2
+

--- a/nix-script-update-package-def.sh
+++ b/nix-script-update-package-def.sh
@@ -12,7 +12,7 @@ source $(dirname ${BASH_SOURCE[0]})/nix-utils.sh
 
 usage() {
     cat <<EOS
-    $(help_synopsis "${BASH_SOURCE[0]}" "[-y] [-b] [-c] [-g <nixpkgs path>] -u <url>")
+    $(help_synopsis "${BASH_SOURCE[0]}" "[-y] [-b] [-c] [-g <nixpkgs path>] [-j <n>] -u <url>")
 
         -y          Don't ask before executing things (optional) (not implemented yet)
         -b          Also test-build the package (optional)
@@ -20,6 +20,7 @@ usage() {
         -g <path>   Path of nixpkgs clone (Default: '$RC_NIXPKGS')
         -c          Don't check out another branch for update
         -d          Don't checkout base branch after successfull run.
+        -j <n>      Pass "-j <n>" to nix-build
         -h          Show this help and exit
 
         Helper for developers of Nix packages.
@@ -47,6 +48,10 @@ usage() {
             # Verbosity is on.
             nix-script -v update-package-def -b -u http://monitor.nixos.org/patch?p=ffmpeg-full&v=2.7.1&m=Matthias+Beyer
 
+$(help_rcvars                                                       \
+    "RC_UPD_NIX_BUILD_J - Default number to pass to 'nix-build -j'"
+)
+
 $(help_end "${BASH_SOURCE[0]}")
 EOS
 }
@@ -57,8 +62,9 @@ NIXPKGS=$RC_NIXPKGS
 URL=
 CHECKOUT=1
 DONT_CHECKOUT_BASE=
+J="$RC_UPD_NIX_BUILD_J"
 
-while getopts "ybu:g:cdh" OPTION
+while getopts "ybu:g:cdj:h" OPTION
 do
     case $OPTION in
         y)
@@ -89,6 +95,11 @@ do
         d)
             DONT_CHECKOUT_BASE=1
             stdout "DONT_CHECKOUT_BASE = $DONT_CHECKOUT_BASE"
+            ;;
+
+        j)
+            J="$OPTARG"
+            stderr "J = $J"
             ;;
 
         h)
@@ -160,7 +171,10 @@ fi
 
 if [[ $TESTBUILD -eq 1 ]]
 then
-    ask_execute "Build '$PKG' in nixpkgs clone at '$NIXPKGS'" nix-build -A $PKG -I $NIXPKGS
+    __j=""
+    [[ ! -z "$J" ]] && __j="-j $J"
+
+    ask_execute "Build '$PKG' in nixpkgs clone at '$NIXPKGS'" nix-build -A $PKG -I $NIXPKGS $__j
 fi
 
 #

--- a/nix-script-update-package-def.sh
+++ b/nix-script-update-package-def.sh
@@ -12,7 +12,7 @@ source $(dirname ${BASH_SOURCE[0]})/nix-utils.sh
 
 usage() {
     cat <<EOS
-    $(help_synopsis "${BASH_SOURCE[0]}" "[-y] [-b] [-c] [-g <nixpkgs path>] [-j <n>] -u <url>")
+    $(help_synopsis "${BASH_SOURCE[0]}" "[-y] [-b] [-c] [-g <nixpkgs path>] [-j <n>] [-C <n>] -u <url>")
 
         -y          Don't ask before executing things (optional) (not implemented yet)
         -b          Also test-build the package (optional)
@@ -21,6 +21,7 @@ usage() {
         -c          Don't check out another branch for update
         -d          Don't checkout base branch after successfull run.
         -j <n>      Pass "-j <n>" to nix-build
+        -C <n>      Pass "--cores <n>" to nix-build
         -h          Show this help and exit
 
         Helper for developers of Nix packages.
@@ -49,7 +50,8 @@ usage() {
             nix-script -v update-package-def -b -u http://monitor.nixos.org/patch?p=ffmpeg-full&v=2.7.1&m=Matthias+Beyer
 
 $(help_rcvars                                                       \
-    "RC_UPD_NIX_BUILD_J - Default number to pass to 'nix-build -j'"
+    "RC_UPD_NIX_BUILD_J     - Default number to pass to 'nix-build -j'"
+    "RC_UPD_NIX_BUILD_CORES - Default number to pass to 'nix-build --cores'"
 )
 
 $(help_end "${BASH_SOURCE[0]}")
@@ -63,8 +65,9 @@ URL=
 CHECKOUT=1
 DONT_CHECKOUT_BASE=
 J="$RC_UPD_NIX_BUILD_J"
+CORES="$RC_UPD_NIX_BUILD_CORES"
 
-while getopts "ybu:g:cdj:h" OPTION
+while getopts "ybu:g:cdj:C:h" OPTION
 do
     case $OPTION in
         y)
@@ -100,6 +103,11 @@ do
         j)
             J="$OPTARG"
             stderr "J = $J"
+            ;;
+
+        C)
+            CORES="$OPTARG"
+            stderr "CORES = $CORES"
             ;;
 
         h)
@@ -174,7 +182,10 @@ then
     __j=""
     [[ ! -z "$J" ]] && __j="-j $J"
 
-    ask_execute "Build '$PKG' in nixpkgs clone at '$NIXPKGS'" nix-build -A $PKG -I $NIXPKGS $__j
+    __cores=""
+    [[ ! -z "$CORES" ]] && __cores="-j $CORES"
+
+    ask_execute "Build '$PKG' in nixpkgs clone at '$NIXPKGS'" nix-build -A $PKG -I $NIXPKGS $__j $__cores
 fi
 
 #


### PR DESCRIPTION
Closes #99 

With these patches we can pass `-j` and `-C` for `-j` and `--cores` in `nix-build` to the `update-package-def` command.

We can also set variables in the configuration for this.