### PR TITLE
Tag with channel

### DIFF
--- a/example.rc
+++ b/example.rc
@@ -78,3 +78,8 @@ RC_UPD_PUSH=0
 #
 RC_UPD_PUSH_REMOTE="github"
 
+#
+# Channel name
+#
+RC_CHANNEL_NAME="unstable"
+

--- a/nix-script
+++ b/nix-script
@@ -146,4 +146,4 @@ SCRIPT_ARGS=$(shift_n $SHIFT_ARGS $*)
 # execute the script with its arguments
 #
 stdout "Calling: '$SCRIPT $SCRIPT_ARGS'"
-RC_CONFIG=$RC_CONFIG RC_NIXPKGS=$RC_NIXPKGS exec bash $SCRIPT $SCRIPT_ARGS
+RC=$RC RC_CONFIG=$RC_CONFIG RC_NIXPKGS=$RC_NIXPKGS exec bash $SCRIPT $SCRIPT_ARGS

--- a/nix-script-channel-update.sh
+++ b/nix-script-channel-update.sh
@@ -7,6 +7,7 @@ usage() {
     $(help_synopsis "channel" "update [-h] [-t <name>] [-w <cfgdir>] [-n]")
 
         -t <name>   | Name for the new tag, instead of nixos-<host>-channel-<num>
+        -n          | Add channel name (from config) in the tag name, currently: $RC_CHANNEL_NAME
         -w <cfgdir> | Alternative config dir, default: $RC_CONFIG
         -n          | DON'T include hostname in tag name
         -h          | Show this help and exit
@@ -16,6 +17,7 @@ EOS
 }
 
 TAG_NAME=""
+ADD_CHANNEL_NAME=0
 CONFIG=$RC_CONFIG
 HOST="$(hostname)"
 
@@ -25,6 +27,11 @@ do
         t)
             TAG_NAME=$OPTARG
             dbg "TAG_NAME = $TAG_NAME"
+            ;;
+
+        n)
+            ADD_CHANNEL_NAME=1
+            dbg "ADD_CHANNEL_NAME = $ADD_CHANNEL_NAME"
             ;;
 
         w)
@@ -59,6 +66,17 @@ if [[ -z "$NAME" ]]
 then
     TAG_NAME="nixos-$([[ ! -z "$HOST" ]] && echo "$HOST-")channel-$(current_channel_generation)"
     stdout "Tag name: '$TAG_NAME'"
+fi
+
+if [[ $ADD_CHANNEL_NAME -eq 1 ]]; then
+    [[ -z "$RC_CHANNEL_NAME" ]] && \
+        stderr "RC SETTING MISSING: RC_CHANNEL_NAME" && exit 1
+
+    dbg "Add the channel name in the tag"
+    TAG_NAME="${TAG_NAME}-${RC_CHANNEL_NAME}"
+    dbg "TAG_NAME = ${TAG_NAME}"
+else
+    dbg "Do not add the channel name in the tag"
 fi
 
 stdout "Resetting sudo password"

--- a/nix-script-channel-update.sh
+++ b/nix-script-channel-update.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 source $(dirname ${BASH_SOURCE[0]})/nix-utils.sh
+[[ -f "$RC" ]] && { dbg "Config file found. Sourcing: '$RC'"; source $RC; }
 
 usage() {
     cat <<EOS

--- a/nix-script-channel.sh
+++ b/nix-script-channel.sh
@@ -51,5 +51,7 @@ stdout "SCRIPT = $SCRIPT"
 stdout "Parsing args for '$1'"
 SCRIPT_ARGS=$(echo $* | sed -r "s/(.*)$1(.*)/\2/")
 
+[[ -f "$RC" ]] && { dbg "Config file found. Sourcing: '$RC'"; source $RC; }
+
 stdout "Calling: '$SCRIPT $SCRIPT_ARGS'"
-RC_CONFIG=$RC_CONFIG RC_NIXPKGS=$RC_NIXPKGS exec bash $SCRIPT $SCRIPT_ARGS
+RC=$RC RC_CONFIG=$RC_CONFIG RC_NIXPKGS=$RC_NIXPKGS exec bash $SCRIPT $SCRIPT_ARGS

--- a/nix-script-switch.sh
+++ b/nix-script-switch.sh
@@ -22,6 +22,8 @@ usage() {
 
         -t <tagname>    Custom tag name
 
+        -C              Append channel generation in tag (<tag>-channel-<gen>)
+
         -p [<pkgs>]     Generate the switch tag in the nixpkgs at <pkgs>
                         as well.  (default: '$RC_NIXPKGS')
 
@@ -78,6 +80,7 @@ COMMAND=switch
 ARGS=
 WD=$RC_CONFIG
 TAG_NAME=
+APPEND_CHANNEL_GEN=
 HOSTNAME="$(hostname)"
 TAG_NIXPKGS=0
 NIXPKGS=$RC_NIXPKGS
@@ -89,7 +92,7 @@ DONT_BUILD=
 QUIET=1
 USE_ALTERNATIVE_SOURCE_NIXPKGS=0
 
-while getopts "c:w:t:nbp:f:qs:r:h" OPTION
+while getopts "c:w:t:Cnbp:f:qs:r:h" OPTION
 do
     case $OPTION in
         c)
@@ -105,6 +108,11 @@ do
         t)
             TAG_NAME=$OPTARG
             dbg "TAG_NAME = $TAG_NAME"
+            ;;
+
+        C)
+            APPEND_CHANNEL_GEN=1
+            dbg "APPEND_CHANNEL_GEN = $APPEND_CHANNEL_GEN"
             ;;
 
         n)
@@ -205,6 +213,14 @@ then
     if [[ -z "$HOSTNAME" ]]; then TAG_NAME="nixos-$LASTGEN-$COMMAND"
     else TAG_NAME="nixos-$HOSTNAME-$LASTGEN-$COMMAND"
     fi
+fi
+
+if [[ $APPEND_CHANNEL_GEN -eq 1 ]]; then
+    dbg "Appending channel generation to tag name"
+    TAG_NAME="${TAG_NAME}-channel-$(current_channel_generation)"
+    dbg "TAG_NAME = $TAG_NAME"
+else
+    dbg "Not appending channel generation to tag name"
 fi
 
 if [[ "$COMMAND" =~ "build" ]]

--- a/nix-utils.sh
+++ b/nix-utils.sh
@@ -143,6 +143,13 @@ current_channel_generation() {
 }
 
 #
+# Get the channel names
+#
+channel_names() {
+    sudo nix-channel --list | cut -d " " -f 1
+}
+
+#
 # Ask the user whether to continue or not
 #
 continue_question() {


### PR DESCRIPTION
Features to be able to tag with channel names.

Should be backwards compatible.

The goal is to add the channel generation in the switch tag (`nix-script switch -C` adds a tag `nixos-42-switch-channel-12`)

Also, the `nix-script channel update` script got an extension (`-n`) to add the channel name in the tag, for when switching channels (`nix-script channel update -n` will add a tag `nixos-channel-42-channel-unstable` if the configuration variable `RC_CHANNEL_NAME` is set to `"unstable"`).

This is not yet tested, but I guess I will try it out with the next channel releases and then merge this if noone complains. Feel free to test as well!

I guess this will bring up a new release (0.4.0) as well.