### PR TITLE
Fix bug when building non-switch and appending channel hash

### DIFF
--- a/nix-script-switch.sh
+++ b/nix-script-switch.sh
@@ -186,6 +186,12 @@ dbg "ARGS = $ARGS"
 
 [[ ! -d "$WD" ]] && stderr "No directory: $WD" && exit 1
 
+[[ "$COMMAND" != "switch" ]] && [[ $APPEND_CHANNEL_GEN == 1 ]] && {
+    stderr "Cannot append channel generation if non-switch build,"
+    stderr "as this is currently not supported."
+    exit 1
+}
+
 TAG_TARGET=$(__quiet__ __git "$WD" rev-parse HEAD)
 stdout "Tag in config will be generated at '$TAG_TARGET'"
 


### PR DESCRIPTION
When we build a non-switch (e.g. "boot") and append the channel hash in
the config tag, we append the wrong hash (not the hash of the channel of
the build generation but the hash of the current channel).

This is a severe bug which is fixed with this commit (by simply failing
to allow the combination of these two flags).

---

Closes #128 